### PR TITLE
Tolerate errors from `apt-get update`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
         else \
           sudo sed -i 's/deb http/deb [arch=amd64] http/g' /etc/apt/sources.list; \
         fi
-        sudo apt-get update
+        sudo apt-get update || true
         sudo apt-get install \
             libstdc++6-$ARCH-cross \
             libc6-dev-$ARCH-cross \

--- a/action.yml
+++ b/action.yml
@@ -25,12 +25,7 @@ runs:
             deb [arch=$ARCH] http://ports.ubuntu.com/ $CODENAME multiverse \n\
             deb [arch=$ARCH] http://ports.ubuntu.com/ $CODENAME-updates multiverse \n\
             deb [arch=$ARCH] http://ports.ubuntu.com/ $CODENAME-backports main restricted universe multiverse \n' > $APTFILE"; fi
-        if [ $ARCH == i386 ]; then \
-          sudo sed -i 's/deb http/deb [arch=amd64,i386] http/g' /etc/apt/sources.list; \
-        else \
-          sudo sed -i 's/deb http/deb [arch=amd64] http/g' /etc/apt/sources.list; \
-        fi
-        sudo apt-get update || true
+        sudo apt-get update
         sudo apt-get install \
             libstdc++6-$ARCH-cross \
             libc6-dev-$ARCH-cross \


### PR DESCRIPTION
This action is used in the repo esp-rs/espflash, and builds have recently started failing because the call to `apt-get update` fails to fetch *some* indexes with the specified architectures.  I've discovered that if I let `apt-get update` do the best it can but I tolerate a non-zero exit status, the rest of the workflow succeeds.  

Here's a link to one of the failures.
https://github.com/esp-rs/espflash/actions/runs/5922460741/job/16056457684#step:3:602