### PR TITLE
Update patch approach since `/etc/apt/sources.list` now uses `deb mirror+file:` sources

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,8 +27,10 @@ runs:
             deb [arch=$ARCH] http://ports.ubuntu.com/ $CODENAME-backports main restricted universe multiverse \n' > $APTFILE"; fi
         if [ $ARCH == i386 ]; then \
           sudo sed -i 's/deb http/deb [arch=amd64,i386] http/g' /etc/apt/sources.list; \
+          sudo sed -i 's/deb mirror/deb [arch=amd64,i386] mirror/g' /etc/apt/sources.list; \
         else \
           sudo sed -i 's/deb http/deb [arch=amd64] http/g' /etc/apt/sources.list; \
+          sudo sed -i 's/deb mirror/deb [arch=amd64] mirror/g' /etc/apt/sources.list; \
         fi
         sudo apt-get update
         sudo apt-get install \


### PR DESCRIPTION
I believe this fixes #5 

After a failed attempt to slap a bandaid on this in #6, I think I have a proper fix here.  This extends the current approach to work effectively with the way `/etc/apt/sources.list` has changed in the GHA runners, and no longer ignores errors.